### PR TITLE
Add Stats Table

### DIFF
--- a/smitearific_api/src/main/java/com/example/demo/RestRepository.java
+++ b/smitearific_api/src/main/java/com/example/demo/RestRepository.java
@@ -2,7 +2,9 @@ package com.example.demo;
 
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.web.bind.annotation.CrossOrigin;
 
 @RepositoryRestResource
+@CrossOrigin("http://localhost:3000")
 public interface RestRepository extends CrudRepository<Gods, Long> {
 }

--- a/smitearific_web_app/components/Navbar.js
+++ b/smitearific_web_app/components/Navbar.js
@@ -18,7 +18,7 @@ function NavBar() {
     useEffect(() => {
         window.addEventListener('load', handlePath);
         handlePage();
-        console.log(path);
+        // console.log(path);
         return () => {
             window.removeEventListener('load', handlePath);
         };

--- a/smitearific_web_app/helpers/statsTableHelpers.js
+++ b/smitearific_web_app/helpers/statsTableHelpers.js
@@ -1,0 +1,29 @@
+function ProperGodNames(response) {
+    for (let i = 0; i < response.data._embedded.godses.length; i++) {
+        const element = response.data._embedded.godses[i];
+        const regex = /^.*[A-Z].*[A-Z].*$/g;
+
+        switch (element.god) {
+            case "AMC":
+                response.data._embedded.godses[i].god = "Ah Muzen Cab";
+                break;
+
+            case "Change":
+                response.data._embedded.godses[i].god = "Chang'e";
+                break;
+
+            default:
+                if (element.god.match(regex)) {
+                    response.data._embedded.godses[i].god = element.god.match(/[A-Z][a-z]+|[0-9]+/g).join(" ");
+                }
+                else {
+                    response.data._embedded.godses[i].god = element.god;
+                }
+                break;
+        }
+    }
+}
+
+export default {
+    ProperGodNames
+}

--- a/smitearific_web_app/package-lock.json
+++ b/smitearific_web_app/package-lock.json
@@ -1862,6 +1862,14 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
+    "axios": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.0.tgz",
+      "integrity": "sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -3749,6 +3757,11 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
       }
+    },
+    "follow-redirects": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
+      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/smitearific_web_app/package-lock.json
+++ b/smitearific_web_app/package-lock.json
@@ -3703,6 +3703,11 @@
         }
       }
     },
+    "file-saver": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.2.tgz",
+      "integrity": "sha512-Wz3c3XQ5xroCxd1G8b7yL0Ehkf0TC9oYC6buPFkNnU9EnaPlifeAFCyCh+iewXTyFRcg0a6j3J7FmJsIhlhBdw=="
+    },
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -5608,6 +5613,14 @@
         "classnames": "^2.2.5",
         "react-transition-group": "^4.2.0",
         "underscore": "1.9.1"
+      }
+    },
+    "react-bootstrap-table2-toolkit": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/react-bootstrap-table2-toolkit/-/react-bootstrap-table2-toolkit-2.1.3.tgz",
+      "integrity": "sha512-nKBSezHTOkO9k8YMMuJfPEZtBVfIYrJbmP8n3u7+AXRcOrOGygXyauNVKWqdKLchQlG/cW5QR0sPkFknpp5rjQ==",
+      "requires": {
+        "file-saver": "2.0.2"
       }
     },
     "react-dom": {

--- a/smitearific_web_app/package-lock.json
+++ b/smitearific_web_app/package-lock.json
@@ -5587,6 +5587,16 @@
         "warning": "^4.0.3"
       }
     },
+    "react-bootstrap-table-next": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/react-bootstrap-table-next/-/react-bootstrap-table-next-4.0.3.tgz",
+      "integrity": "sha512-uKxC73qUdUfusRf2uzDfMiF9LvTG5vuhTZa0lbAgHWSLLLaKTsI0iHf1e4+c7gP71q8dFsp7StvkP65SxC1JRg==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "react-transition-group": "^4.2.0",
+        "underscore": "1.9.1"
+      }
+    },
     "react-dom": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
@@ -6955,6 +6965,11 @@
         "invariant": "^2.2.4",
         "react-lifecycles-compat": "^3.0.4"
       }
+    },
+    "underscore": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",

--- a/smitearific_web_app/package.json
+++ b/smitearific_web_app/package.json
@@ -19,6 +19,7 @@
     "next-optimized-images": "^3.0.0-canary.10",
     "react": "16.13.1",
     "react-bootstrap": "^1.3.0",
+    "react-bootstrap-table-next": "^4.0.3",
     "react-dom": "16.13.1",
     "sass": "^1.26.12"
   }

--- a/smitearific_web_app/package.json
+++ b/smitearific_web_app/package.json
@@ -21,6 +21,7 @@
     "react": "16.13.1",
     "react-bootstrap": "^1.3.0",
     "react-bootstrap-table-next": "^4.0.3",
+    "react-bootstrap-table2-toolkit": "^2.1.3",
     "react-dom": "16.13.1",
     "sass": "^1.26.12"
   }

--- a/smitearific_web_app/package.json
+++ b/smitearific_web_app/package.json
@@ -13,6 +13,7 @@
     "@fortawesome/free-regular-svg-icons": "^5.15.1",
     "@fortawesome/free-solid-svg-icons": "^5.15.1",
     "@fortawesome/react-fontawesome": "^0.1.11",
+    "axios": "^0.21.0",
     "bootstrap": "^4.5.2",
     "next": "9.5.3",
     "next-compose-plugins": "^2.2.0",

--- a/smitearific_web_app/pages/_app.js
+++ b/smitearific_web_app/pages/_app.js
@@ -1,4 +1,5 @@
 import '../styles/main.scss'
+import 'react-bootstrap-table-next/dist/react-bootstrap-table2.min.css';
 
 function MyApp({ Component, pageProps }) {
   return <Component {...pageProps} />

--- a/smitearific_web_app/pages/esports-stats.js
+++ b/smitearific_web_app/pages/esports-stats.js
@@ -1,16 +1,118 @@
-import { useRouter } from 'next/router'
+import React, { useState, useEffect, useRef } from 'react';
 import Navbar from '../components/Navbar.js';
-import NavigationEsports from '../components/navigationEsports.js';
 import ScrollArrow from '../components/scrollArrow.js';
+import { Button, ButtonGroup } from 'react-bootstrap';
+import BootstrapTable from 'react-bootstrap-table-next';
+import ToolkitProvider, { Search } from 'react-bootstrap-table2-toolkit';
+import GodsService from '../services/GodsService';
+import statsTableHelpers from '../helpers/statsTableHelpers';
 
-export default function Esports() {
-    const { asPath } = useRouter()
+export default function EsportsStats() {
+    const [godData, setGodData] = useState([]);
+    const { SearchBar } = Search;
+    const searcBar = useRef(null);
+
+    useEffect(() => {
+        GodsService.GetGods()
+            .then(
+                response => {
+                    statsTableHelpers.ProperGodNames(response);
+                    setGodData(response.data._embedded.godses);
+                }
+            )
+    }, []);
+
+    const searchSolo = () => {
+        searcBar.current.props.onSearch("Solo");
+    };
+    const searchJung = () => {
+        searcBar.current.props.onSearch("Jung");
+    };
+    const searchMid = () => {
+        searcBar.current.props.onSearch("Mid");
+    };
+    const searchAdc = () => {
+        searcBar.current.props.onSearch("ADC");
+    };
+    const searchSupp = () => {
+        searcBar.current.props.onSearch("Supp");
+    };
+
+    const columns = [{
+        dataField: 'god',
+        text: 'God',
+        sort: true,
+        title: true,
+    }, {
+        dataField: 'winRate',
+        text: 'Win Rate',
+        sort: true,
+        searchable: false
+    }, {
+        dataField: 'pickRate',
+        text: 'Pick Rate',
+        sort: true,
+        searchable: false
+    }, {
+        dataField: 'banRate',
+        text: 'Ban Rate',
+        sort: true,
+        searchable: false
+    }, {
+        dataField: 'pandBRate',
+        text: 'Pick & Ban Rate',
+        sort: true,
+        searchable: false
+    }, {
+        dataField: 'role',
+        text: 'Role',
+        hidden: true
+    }, {
+        dataField: 'secondaryRole',
+        text: '2nd Role',
+        hidden: true
+    }];
+
+    const defaultSorted = [{
+        dataField: 'pandBRate',
+        order: 'desc'
+    }];
     return (
         <>
             <Navbar />
-            <NavigationEsports />
             <ScrollArrow />
-            <p>This is the {asPath} page</p>
+
+            <div className="tableContainer">
+                <ToolkitProvider
+                    bootstrap4
+                    keyField="god"
+                    data={godData}
+                    columns={columns}
+                    search
+                >
+                    {
+                        props => (
+                            <div>
+                                <div className="d-flex mb-4 justify-content-between align-items-center">
+                                    <SearchBar ref={searcBar} {...props.searchProps} />
+                                    <ButtonGroup>
+                                        <Button variant="light"><img onClick={searchSolo} className="roleStatsIcon" alt="solo" src="https://i.imgur.com/7G2OSFj.png"></img></Button>
+                                        <Button variant="light"><img onClick={searchJung} className="roleStatsIcon" alt="jung" src="https://i.imgur.com/l1BUe0w.png"></img></Button>
+                                        <Button variant="light"><img onClick={searchMid} className="roleStatsIcon" alt="mid" src="https://i.imgur.com/8LgQst7.png"></img></Button>
+                                        <Button variant="light"><img onClick={searchAdc} className="roleStatsIcon" alt="adc" src="https://i.imgur.com/O6RRFBd.png"></img></Button>
+                                        <Button variant="light"><img onClick={searchSupp} className="roleStatsIcon" alt="supp" src="https://i.imgur.com/FsktGB1.png"></img></Button>
+                                    </ButtonGroup>
+                                </div>
+                                <BootstrapTable
+                                    {...props.baseProps}
+                                    defaultSorted={defaultSorted}
+                                    headerClasses="rounded"
+                                />
+                            </div>
+                        )
+                    }
+                </ToolkitProvider>
+            </div>
         </>
     )
 }

--- a/smitearific_web_app/pages/god-stats.js
+++ b/smitearific_web_app/pages/god-stats.js
@@ -1,14 +1,59 @@
 import { useRouter } from 'next/router'
 import Navbar from '../components/Navbar.js';
 import ScrollArrow from '../components/scrollArrow.js';
+import BootstrapTable from 'react-bootstrap-table-next';
 
 export default function GodStats() {
     const { asPath } = useRouter()
+    const products = [{
+        "id": 1,
+        "name": "Name 1",
+        "price": 1.50,
+    }, {
+        "id": 2,
+        "name": "Name 2",
+        "price": 3.00,
+    }, {
+        "id": 3,
+        "name": "Name 3",
+        "price": 10.00,
+    }, {
+        "id": 4,
+        "name": "Name 4",
+        "price": 9.99,
+    }]
+    const columns = [{
+        dataField: 'id',
+        text: 'Product ID',
+        sort: true
+    }, {
+        dataField: 'name',
+        text: 'Product Name',
+        sort: true
+    }, {
+        dataField: 'price',
+        text: 'Product Price',
+        sort: true
+    }];
+
+    const defaultSorted = [{
+        dataField: 'name',
+        order: 'desc'
+    }];
     return (
         <>
             <Navbar />
             <ScrollArrow />
             <p>This is the {asPath} page</p>
+
+            <BootstrapTable
+                className="text-white"
+                bootstrap4
+                keyField="id"
+                data={products}
+                columns={columns}
+                defaultSorted={defaultSorted}
+            />
         </>
     )
 }

--- a/smitearific_web_app/pages/god-stats.js
+++ b/smitearific_web_app/pages/god-stats.js
@@ -1,19 +1,39 @@
 import React, { useState, useEffect } from 'react';
-import { useRouter } from 'next/router';
 import Navbar from '../components/Navbar.js';
 import ScrollArrow from '../components/scrollArrow.js';
 import BootstrapTable from 'react-bootstrap-table-next';
-import axios from "axios";
 import GodsService from '../services/GodsService';
 
 export default function GodStats() {
-    const { asPath } = useRouter();
     const [godData, setGodData] = useState([]);
 
     useEffect(() => {
         GodsService.GetGods()
             .then(
                 response => {
+                    for (let i = 0; i < response.data._embedded.godses.length; i++) {
+                        const element = response.data._embedded.godses[i];
+                        const regex = /^.*[A-Z].*[A-Z].*$/g;
+
+                        switch (element.god) {
+                            case "AMC":
+                                response.data._embedded.godses[i].god = "Ah Muzen Cab";
+                                break;
+
+                            case "Change":
+                                response.data._embedded.godses[i].god = "Chang'e";
+                                break;
+
+                            default:
+                                if (element.god.match(regex)) {
+                                    response.data._embedded.godses[i].god = element.god.match(/[A-Z][a-z]+|[0-9]+/g).join(" ");
+                                }
+                                else {
+                                    response.data._embedded.godses[i].god = element.god;
+                                }
+                                break;
+                        }
+                    }
                     setGodData(response.data._embedded.godses);
                 }
             )
@@ -28,32 +48,16 @@ export default function GodStats() {
         text: 'Win Rate',
         sort: true
     }, {
-        dataField: 'prevWinRate',
-        text: 'Previous Win Rate',
-        sort: true
-    }, {
         dataField: 'pickRate',
         text: 'Pick Rate',
-        sort: true
-    }, {
-        dataField: 'prevPickRate',
-        text: 'Previous Pick Rate',
         sort: true
     }, {
         dataField: 'banRate',
         text: 'Ban Rate',
         sort: true
     }, {
-        dataField: 'prevBanRate',
-        text: 'Previous Ban Rate',
-        sort: true
-    }, {
         dataField: 'pandBRate',
-        text: 'Pick and Ban Rate',
-        sort: true
-    }, {
-        dataField: 'prevPAndBRate',
-        text: 'Previous Pick and Ban Rate',
+        text: 'Pick & Ban Rate',
         sort: true
     }, {
         dataField: 'role',
@@ -73,7 +77,6 @@ export default function GodStats() {
         <>
             <Navbar />
             <ScrollArrow />
-            <p>This is the {asPath} page</p>
 
             <BootstrapTable
                 bootstrap4

--- a/smitearific_web_app/pages/god-stats.js
+++ b/smitearific_web_app/pages/god-stats.js
@@ -1,90 +1,118 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import Navbar from '../components/Navbar.js';
 import ScrollArrow from '../components/scrollArrow.js';
+import { Button, ButtonGroup } from 'react-bootstrap';
 import BootstrapTable from 'react-bootstrap-table-next';
+import ToolkitProvider, { Search } from 'react-bootstrap-table2-toolkit';
 import GodsService from '../services/GodsService';
+import statsTableHelpers from '../helpers/statsTableHelpers';
 
 export default function GodStats() {
     const [godData, setGodData] = useState([]);
+    const { SearchBar } = Search;
+    const searcBar = useRef(null);
 
     useEffect(() => {
         GodsService.GetGods()
             .then(
                 response => {
-                    for (let i = 0; i < response.data._embedded.godses.length; i++) {
-                        const element = response.data._embedded.godses[i];
-                        const regex = /^.*[A-Z].*[A-Z].*$/g;
-
-                        switch (element.god) {
-                            case "AMC":
-                                response.data._embedded.godses[i].god = "Ah Muzen Cab";
-                                break;
-
-                            case "Change":
-                                response.data._embedded.godses[i].god = "Chang'e";
-                                break;
-
-                            default:
-                                if (element.god.match(regex)) {
-                                    response.data._embedded.godses[i].god = element.god.match(/[A-Z][a-z]+|[0-9]+/g).join(" ");
-                                }
-                                else {
-                                    response.data._embedded.godses[i].god = element.god;
-                                }
-                                break;
-                        }
-                    }
+                    statsTableHelpers.ProperGodNames(response);
                     setGodData(response.data._embedded.godses);
                 }
             )
-    }, [])
+    }, []);
+
+    const searchSolo = () => {
+        searcBar.current.props.onSearch("Solo");
+    };
+    const searchJung = () => {
+        searcBar.current.props.onSearch("Jung");
+    };
+    const searchMid = () => {
+        searcBar.current.props.onSearch("Mid");
+    };
+    const searchAdc = () => {
+        searcBar.current.props.onSearch("ADC");
+    };
+    const searchSupp = () => {
+        searcBar.current.props.onSearch("Supp");
+    };
 
     const columns = [{
         dataField: 'god',
         text: 'God',
-        sort: true
+        sort: true,
+        title: true,
     }, {
         dataField: 'winRate',
         text: 'Win Rate',
-        sort: true
+        sort: true,
+        searchable: false
     }, {
         dataField: 'pickRate',
         text: 'Pick Rate',
-        sort: true
+        sort: true,
+        searchable: false
     }, {
         dataField: 'banRate',
         text: 'Ban Rate',
-        sort: true
+        sort: true,
+        searchable: false
     }, {
         dataField: 'pandBRate',
         text: 'Pick & Ban Rate',
-        sort: true
+        sort: true,
+        searchable: false
     }, {
         dataField: 'role',
         text: 'Role',
-        sort: true
+        hidden: true
     }, {
         dataField: 'secondaryRole',
-        text: 'Secondary Role',
-        sort: true
+        text: '2nd Role',
+        hidden: true
     }];
 
     const defaultSorted = [{
-        dataField: 'god',
-        order: 'asc'
+        dataField: 'pandBRate',
+        order: 'desc'
     }];
     return (
         <>
             <Navbar />
             <ScrollArrow />
 
-            <BootstrapTable
-                bootstrap4
-                keyField="god"
-                data={godData}
-                columns={columns}
-                defaultSorted={defaultSorted}
-            />
+            <div className="tableContainer">
+                <ToolkitProvider
+                    bootstrap4
+                    keyField="god"
+                    data={godData}
+                    columns={columns}
+                    search
+                >
+                    {
+                        props => (
+                            <div>
+                                <div className="d-flex mb-4 justify-content-between align-items-center">
+                                    <SearchBar ref={searcBar} {...props.searchProps} />
+                                    <ButtonGroup>
+                                        <Button variant="light"><img onClick={searchSolo} className="roleStatsIcon" alt="solo" src="https://i.imgur.com/7G2OSFj.png"></img></Button>
+                                        <Button variant="light"><img onClick={searchJung} className="roleStatsIcon" alt="jung" src="https://i.imgur.com/l1BUe0w.png"></img></Button>
+                                        <Button variant="light"><img onClick={searchMid} className="roleStatsIcon" alt="mid" src="https://i.imgur.com/8LgQst7.png"></img></Button>
+                                        <Button variant="light"><img onClick={searchAdc} className="roleStatsIcon" alt="adc" src="https://i.imgur.com/O6RRFBd.png"></img></Button>
+                                        <Button variant="light"><img onClick={searchSupp} className="roleStatsIcon" alt="supp" src="https://i.imgur.com/FsktGB1.png"></img></Button>
+                                    </ButtonGroup>
+                                </div>
+                                <BootstrapTable
+                                    {...props.baseProps}
+                                    defaultSorted={defaultSorted}
+                                    headerClasses="rounded"
+                                />
+                            </div>
+                        )
+                    }
+                </ToolkitProvider>
+            </div>
         </>
     )
 }

--- a/smitearific_web_app/pages/god-stats.js
+++ b/smitearific_web_app/pages/god-stats.js
@@ -1,44 +1,73 @@
-import { useRouter } from 'next/router'
+import React, { useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
 import Navbar from '../components/Navbar.js';
 import ScrollArrow from '../components/scrollArrow.js';
 import BootstrapTable from 'react-bootstrap-table-next';
+import axios from "axios";
+import GodsService from '../services/GodsService';
 
 export default function GodStats() {
-    const { asPath } = useRouter()
-    const products = [{
-        "id": 1,
-        "name": "Name 1",
-        "price": 1.50,
-    }, {
-        "id": 2,
-        "name": "Name 2",
-        "price": 3.00,
-    }, {
-        "id": 3,
-        "name": "Name 3",
-        "price": 10.00,
-    }, {
-        "id": 4,
-        "name": "Name 4",
-        "price": 9.99,
-    }]
+    const { asPath } = useRouter();
+    const [godData, setGodData] = useState([]);
+
+    useEffect(() => {
+        GodsService.GetGods()
+            .then(
+                response => {
+                    setGodData(response.data._embedded.godses);
+                }
+            )
+    }, [])
+
     const columns = [{
-        dataField: 'id',
-        text: 'Product ID',
+        dataField: 'god',
+        text: 'God',
         sort: true
     }, {
-        dataField: 'name',
-        text: 'Product Name',
+        dataField: 'winRate',
+        text: 'Win Rate',
         sort: true
     }, {
-        dataField: 'price',
-        text: 'Product Price',
+        dataField: 'prevWinRate',
+        text: 'Previous Win Rate',
+        sort: true
+    }, {
+        dataField: 'pickRate',
+        text: 'Pick Rate',
+        sort: true
+    }, {
+        dataField: 'prevPickRate',
+        text: 'Previous Pick Rate',
+        sort: true
+    }, {
+        dataField: 'banRate',
+        text: 'Ban Rate',
+        sort: true
+    }, {
+        dataField: 'prevBanRate',
+        text: 'Previous Ban Rate',
+        sort: true
+    }, {
+        dataField: 'pandBRate',
+        text: 'Pick and Ban Rate',
+        sort: true
+    }, {
+        dataField: 'prevPAndBRate',
+        text: 'Previous Pick and Ban Rate',
+        sort: true
+    }, {
+        dataField: 'role',
+        text: 'Role',
+        sort: true
+    }, {
+        dataField: 'secondaryRole',
+        text: 'Secondary Role',
         sort: true
     }];
 
     const defaultSorted = [{
-        dataField: 'name',
-        order: 'desc'
+        dataField: 'god',
+        order: 'asc'
     }];
     return (
         <>
@@ -47,10 +76,9 @@ export default function GodStats() {
             <p>This is the {asPath} page</p>
 
             <BootstrapTable
-                className="text-white"
                 bootstrap4
-                keyField="id"
-                data={products}
+                keyField="god"
+                data={godData}
                 columns={columns}
                 defaultSorted={defaultSorted}
             />

--- a/smitearific_web_app/services/GodsService.js
+++ b/smitearific_web_app/services/GodsService.js
@@ -1,0 +1,9 @@
+import http from './http-common.js';
+
+const GetGods = () => {
+    return http.httpdefault().get("godses", { timeout: 5000 });
+};
+
+export default {
+    GetGods
+};

--- a/smitearific_web_app/services/http-common.js
+++ b/smitearific_web_app/services/http-common.js
@@ -1,0 +1,14 @@
+import axios from "axios";
+
+const httpdefault = () => {
+    return axios.create({
+        baseURL: "http://localhost:8080/",
+        headers: {
+            "Content-type": "application/json"
+        }
+    })
+};
+
+export default {
+    httpdefault,
+};

--- a/smitearific_web_app/styles/components/_statsTable.scss
+++ b/smitearific_web_app/styles/components/_statsTable.scss
@@ -1,0 +1,3 @@
+.react-bootstrap-table table {
+    color: $white;
+}

--- a/smitearific_web_app/styles/components/_statsTable.scss
+++ b/smitearific_web_app/styles/components/_statsTable.scss
@@ -1,3 +1,76 @@
-.react-bootstrap-table table {
-    color: $white;
+.tableContainer {
+    width: 60%;
+    margin: 2rem auto auto auto;
+
+    .godStatsIcon {
+        width: 40px;
+        height: 40px;
+        border-radius: 50px;
+        margin: auto auto auto 1.2rem;
+    }
+
+    .roleStatsIcon {
+        width: 40px;
+        height: 40px;
+        border-radius: 50px;
+    }
+
+    .react-bootstrap-table table {
+        color: $white;
+        
+        tr{
+                        
+            &:first-child {
+                border-top-left-radius: 21px;
+                border-top-right-radius: 21px;
+            }
+        }
+    }
+
+    .search-label {
+        width: 36%;
+
+        input {
+            padding: 1.6rem 0.5rem;
+            border: 2px solid $gold;
+            border-radius: 20px;
+
+            &:focus {
+                box-shadow: none;
+            }
+        }
+    }
+
+    .btn-group {
+        .btn-light {
+
+            &:first-child {
+                border-radius: 20px;
+                border-top-right-radius: 0px;
+                border-bottom-right-radius: 0px;
+            }
+
+            &:last-child {
+                border-radius: 20px;
+                border-top-left-radius: 0px;
+                border-bottom-left-radius: 0px;
+            }
+
+            &:active {
+                border-color: $gold;
+            }
+
+            &:focus {
+                background-color: $white;
+                border-color: $gold;
+                box-shadow: 0 0 0 0.2rem rgba(191, 155, 48, 0.8);
+            }
+
+            &:hover {
+                background-color: $white;
+                border-color: $gold;
+                box-shadow: 0 0 0 0.2rem rgba(191, 155, 48, 0.8);
+            }
+        }
+    }
 }

--- a/smitearific_web_app/styles/main.scss
+++ b/smitearific_web_app/styles/main.scss
@@ -12,6 +12,7 @@
 @import './components/navbar';
 @import './components/nav';
 @import './components/scrollArrow';
+@import './components/statsTable';
 
 // Pages
 @import './pages/blog';


### PR DESCRIPTION
Added god stats table, that pulls from my API to get the data and display it in a sortable, searchable and filterable (via buttons) table. The table was added to the `/god-stats` and `/esports-stats` pages.
- Add a sortable and searchable table
- Add buttons to filter the table by roles
- Connected the table to the API to display the data